### PR TITLE
Bug fix #4 - Updated [is_archived] null value in where clause

### DIFF
--- a/FiveTran Transformations/FHH/tr.fhh_contact_stage
+++ b/FiveTran Transformations/FHH/tr.fhh_contact_stage
@@ -582,7 +582,7 @@ USING(
       FROM Dunham.fhh.gift
       where [recurring_gift_payments_gift_contact_id] is not null
     ) g on g.[contact_id] = c.[id]
-   WHERE [id] IS NOT NULL and [is_archived]<>1) AS source
+   WHERE [id] IS NOT NULL and ([is_archived]<>1 or [is_archived] IS NULL) AS source
    ON (target.[pk_constituent_id] = source.[pk_constituent_id])
 
    /*inserts .contact rows that are not found in .contact_stage rows*/

--- a/FiveTran Transformations/FHH/tr.fhh_contact_stage
+++ b/FiveTran Transformations/FHH/tr.fhh_contact_stage
@@ -582,7 +582,7 @@ USING(
       FROM Dunham.fhh.gift
       where [recurring_gift_payments_gift_contact_id] is not null
     ) g on g.[contact_id] = c.[id]
-   WHERE [id] IS NOT NULL and ([is_archived]<>1 or [is_archived] IS NULL) AS source
+   WHERE [id] IS NOT NULL and ([is_archived]<>1 or [is_archived] IS NULL)) AS source
    ON (target.[pk_constituent_id] = source.[pk_constituent_id])
 
    /*inserts .contact rows that are not found in .contact_stage rows*/

--- a/FiveTran Transformations/GIL/tr.gil_contact_stage
+++ b/FiveTran Transformations/GIL/tr.gil_contact_stage
@@ -528,7 +528,7 @@ USING(
 			UPPER('gil') as [client_acronym]
 
 	 FROM [Dunham].[gil].[contact]
-   WHERE [id] IS NOT NULL and [is_archived]<>1) AS source
+ WHERE [id] IS NOT NULL and ([is_archived]<>1 OR [is_archived] IS NULL)) AS source
    ON (target.[pk_constituent_id] = source.[pk_constituent_id] collate SQL_Latin1_General_CP1_CI_AS)
 
    /*inserts .contact rows that are not found in .contact_stage rows*/

--- a/FiveTran Transformations/PPC/tr.ppc_contact_stage
+++ b/FiveTran Transformations/PPC/tr.ppc_contact_stage
@@ -526,7 +526,7 @@ USING(
 			UPPER('ppc') as [client_acronym]
 
 	 FROM [Dunham].[ppc].[contact]
-   WHERE [id] IS NOT NULL and [is_archived]<>1) AS source
+   WHERE [id] IS NOT NULL and ([is_archived]<>1 OR [is_archived] IS NULL)) AS source
    ON (target.[pk_constituent_id] = source.[pk_constituent_id])
 
    /*inserts .contact rows that are not found in .contact_stage rows*/

--- a/FiveTran Transformations/WFM/tr.wfm_contact_stage
+++ b/FiveTran Transformations/WFM/tr.wfm_contact_stage
@@ -559,7 +559,7 @@ USING(
      FROM Dunham.wfm.gift
      where [recurring_gift_payments_gift_contact_id] is not null
    ) g on g.[contact_id] = c.[id]
-   WHERE [id] IS NOT NULL and [is_archived]<>1) AS source
+ WHERE [id] IS NOT NULL and ([is_archived]<>1 OR [is_archived] IS NULL)) AS source
    ON (target.[pk_constituent_id] = source.[pk_constituent_id] collate SQL_Latin1_General_CP1_CI_AS)
 
    /*inserts .contact rows that are not found in .contact_stage rows*/


### PR DESCRIPTION
Updated all where clause filters to include [is_archived] null values to eliminated donor file truncation due to Virtuous archived boolean updates.

Fixes #4 